### PR TITLE
Crash upon search error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 0.0.3-1 (2023-03-19)
+
+- Handle 4XX errors in `BaseSearchHandler` by retrying.
+- If errors persist in `BaseSearchHandler`, `RuntimeError` is raised.

--- a/db_builders/base_search.py
+++ b/db_builders/base_search.py
@@ -39,12 +39,20 @@ class BaseSearchHandler:
     async def perform_search(self, query: str, num_results: int = 100) -> list[SearchResultItem]:
         """ Perform a search using the Google custom search API
 
+        # Status code handlers:
+        - If the status code is 4XX or 5XX, the search will be retried up to 3 times.
+        - If the status code is not 200, 4XX, or 5XX, the status code will be printed and the search will be skipped.
+
         Parameters:
             `query`: The query string which will be used to search.
             `num_results`: The number of results to return. Defaults to 100.
 
         Returns:
             A list of `SearchResultItem` objects.
+
+            However, if an error occurs and cannot be resolved, an empty list will be returned. Errors include
+            4XX or 5XX status codes (after a retry limit has been hit), or if the response does not contain the expected
+            data.
         """
         results = []
 
@@ -64,21 +72,18 @@ class BaseSearchHandler:
                     url += f"&num={num_results}"
 
                 async with session.get(url) as resp:
-
-                    # repeat search if 5XX error is returned
-                    if 500 <= resp.status < 600:
+                    # repeat search if 4XX or 5XX error is returned
+                    if 400 <= resp.status < 600:
                         if self.retry_count >= self.MAX_RETRY_COUNT:
-                            warnings.warn(f"Got status code {resp.status} from Google API. "
-                                          f"Retried {self.retry_count} times. Skipping...")
-                            continue
+                            print(await resp.text())
+                            raise RuntimeError(f"Got status code {resp.status} from Google API. "
+                                               f"Retried {self.retry_count} times. Skipping...")
                         self.retry_count += 1
-                        print(f"Got status code {resp.status} from Google API. Retrying after 30 secs...")
                         await sleep(30)
                         await self.perform_search(query, num_results)
                     if resp.status != 200:
-                        print(f"Got status code {resp.status} from Google API.")
                         print(await resp.text())
-                        continue
+                        raise RuntimeError(f"Got status code {resp.status} from Google API.")
 
                     self.retry_count = 0
 

--- a/db_builders/utils.py
+++ b/db_builders/utils.py
@@ -7,6 +7,16 @@ from openai import RateLimitError, InternalServerError, APIConnectionError, APIT
 from db_builders.typedefs import SearchResultItem
 
 
+# List of keywords to exclude from search results
+EXCLUDE_LIST = ['amazon', 'china', 'india', 'co.uk', '.cn', '.in', 'ebay', 'lowes', 'homedepot', 'walmart',
+                'target.com', '.gov', 'acehardware', 'business', 'news', 'alibaba', 'aliexpress', 'wikipedia',
+                'youtube', 'facebook', 'twitter', 'instagram', 'pinterest', 'linkedin', 'yelp', 'bbb', 'glassdoor',
+                'biz', 'bloomberg', 'forbes.com', 'fortune.com', 'inc', 'investopedia', 'money', 'nasdaq', 'nyse',
+                'reuters', 'seekingalpha', 'stocktwits', 'thestreet', 'wsj', 'yahoo', 'yahoofinance', 'zacks.com',
+                'barrons.com', 'bloomberg', 'cnbc', 'cnn', 'foxbusiness', 'marketwatch', 'msn', 'newsmax', 'npr',
+                'samsclub', 'costco', 'overstock', 'sears', 'kmart', 'wayfair', 'etsy']
+
+
 def retry_on_ratelimit():
     """ Decorator which retries an asynchronous OpenAI call if a RateLimitError or any other openai error is raised. """
     def decorator(func):
@@ -74,11 +84,4 @@ def filter_results(results: list[SearchResultItem]) -> list[SearchResultItem]:
     Returns:
         List of valid `SearchResultItem` objects
     """
-    exclude = ['amazon', 'china', 'india', 'co.uk', '.cn', '.in', 'ebay', 'lowes', 'homedepot', 'walmart',
-               'target.com', '.gov', 'acehardware', 'business', 'news', 'alibaba', 'aliexpress', 'wikipedia',
-               'youtube', 'facebook', 'twitter', 'instagram', 'pinterest', 'linkedin', 'yelp', 'bbb', 'glassdoor',
-               'biz', 'bloomberg', 'forbes.com', 'fortune.com', 'inc', 'investopedia', 'money', 'nasdaq', 'nyse',
-               'reuters', 'seekingalpha', 'stocktwits', 'thestreet', 'wsj', 'yahoo', 'yahoofinance', 'zacks.com',
-               'barrons.com', 'bloomberg', 'cnbc', 'cnn', 'foxbusiness', 'marketwatch', 'msn', 'newsmax', 'npr',
-               'samsclub', 'costco', 'overstock', 'sears', 'kmart', 'wayfair', 'etsy']
-    return [result for result in results if not any(word in result.link for word in exclude)]
+    return [result for result in results if not any(word in result.link for word in EXCLUDE_LIST)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "db_builders"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
     "langchain",
     "langchain_openai",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "db_builders"
-version = "0.0.3"
+version = "0.0.3-1"
 dependencies = [
     "langchain",
     "langchain_openai",


### PR DESCRIPTION
Version bump to 0.0.3-1

- Crash upon any unhandled status codes in `BaseSearchHandler`
- Handle 4XX status codes by retrying. Crash if status code cannot be resolved.
- Add CHANGELOG.md

This closes [#33 for `bimWorkshopBackend`](https://github.com/PoorRican/bimWorkshopBackend/issues/33)